### PR TITLE
add python 3.11 build

### DIFF
--- a/.github/workflows/sdk_validation.yaml
+++ b/.github/workflows/sdk_validation.yaml
@@ -8,6 +8,10 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.8', '3.11' ]
+    name: Python ${{ matrix.python-version }}
     timeout-minutes: 10
     env:
       SHIPPO_TOKEN: ${{ secrets.SHIPPO_TOKEN }}
@@ -20,7 +24,7 @@ jobs:
         id: setup_python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
       - name: cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/sdk_validation.yaml
+++ b/.github/workflows/sdk_validation.yaml
@@ -44,6 +44,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-${{ matrix.python-version }}
           path: |
             build/test_results


### PR DESCRIPTION
we recently had an issue with the sdk which only manifested in 3.11, so adding validation against both 3.8 and 3.11