### PR TITLE
Clean up pipeline

### DIFF
--- a/.github/workflows/sdk_validation.yaml
+++ b/.github/workflows/sdk_validation.yaml
@@ -1,9 +1,13 @@
 name: Validate
 
 on:
-  workflow_call:
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   check:


### PR DESCRIPTION
Reasoning: Auto-generated PRs are not triggering the validation step as they should.
See example [here](https://github.com/goshippo/shippo-python-sdk/pull/93)